### PR TITLE
account for quirks of timestamp passed to rAF callback

### DIFF
--- a/src/Native/AnimationFrame.js
+++ b/src/Native/AnimationFrame.js
@@ -5,8 +5,9 @@ var rAF = _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 {
 	var id = requestAnimationFrame(function(time) {
 		var now = Date.now();
+		var normalizedTime = performance.timing.navigationStart + time;
 		var yieldedTime = time ?
-			(time < now ? (performance.timing.navigationStart + time) : time) :
+			(normalizedTime > now ? time : normalizedTime) :
 			now;
 		
 		callback(_elm_lang$core$Native_Scheduler.succeed(yieldedTime));

--- a/src/Native/AnimationFrame.js
+++ b/src/Native/AnimationFrame.js
@@ -1,10 +1,13 @@
 var _elm_lang$animation_frame$Native_AnimationFrame = function()
 {
+	
+var navStart = window.performance && window.performance.timing && window.performance.timing.navigationStart ?
+	window.performance.timing.navigationStart :
+	Date.now();
 
 var rAF = _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 {
 	var id = requestAnimationFrame(function(time) {
-		var navStart = performance.timing.navigationStart;
 		var yieldedTime = time ?
 			(time > navStart ? time : time + navStart) :
 			Date.now();

--- a/src/Native/AnimationFrame.js
+++ b/src/Native/AnimationFrame.js
@@ -4,7 +4,12 @@ var _elm_lang$animation_frame$Native_AnimationFrame = function()
 var rAF = _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 {
 	var id = requestAnimationFrame(function(time) {
-		callback(_elm_lang$core$Native_Scheduler.succeed(time || Time.now()));
+		var now = Date.now();
+		var yieldedTime = time ?
+			(time < now ? (performance.timing.navigationStart + time) : time) :
+			now;
+		
+		callback(_elm_lang$core$Native_Scheduler.succeed(yieldedTime));
 	});
 
 	return function() {

--- a/src/Native/AnimationFrame.js
+++ b/src/Native/AnimationFrame.js
@@ -5,9 +5,9 @@ var rAF = _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 {
 	var id = requestAnimationFrame(function(time) {
 		var now = Date.now();
-		var normalizedTime = performance.timing.navigationStart + time;
+		var navStart = performance.timing.navigationStart;
 		var yieldedTime = time ?
-			(normalizedTime > now ? time : normalizedTime) :
+			(time > navStart ? time : time + navStart) :
 			now;
 		
 		callback(_elm_lang$core$Native_Scheduler.succeed(yieldedTime));

--- a/src/Native/AnimationFrame.js
+++ b/src/Native/AnimationFrame.js
@@ -4,11 +4,10 @@ var _elm_lang$animation_frame$Native_AnimationFrame = function()
 var rAF = _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 {
 	var id = requestAnimationFrame(function(time) {
-		var now = Date.now();
 		var navStart = performance.timing.navigationStart;
 		var yieldedTime = time ?
 			(time > navStart ? time : time + navStart) :
-			now;
+			Date.now();
 		
 		callback(_elm_lang$core$Native_Scheduler.succeed(yieldedTime));
 	});


### PR DESCRIPTION
I was updating my personal TEA port to use animation-frame for the spinning squares and found some issues (that I know how to fix this time! 😄 )

This PR fixes one issue and proposes a fix to another:
- `Time.now()` is not a thing in scope here and I think it should be `Date.now()` (?)
- The value of `time` passed into the rAF callback has the following oddities:
  - According to the WHATWG spec it is supposed to be relative to `performance.timing.navigationStart` rather than the unix epoch, so if the value passed in to Elm programs is going to be consistent across browsers and make sense when used in conjunction with `Time.now` that value should be added. I added a safe lookup / workaround for if the nav timing api isn't available as well.
  - Some older implementations (I think just Firefox) don't follow that spec and deliver the value relative to the unix epoch anyway, so there's a difference check in there to see if that is the case.

Details on the behavior of that timestamp are mostly in footnote [2] under browser compatibility on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame)

I went through a couple iterations on how to check what the timestamp is relative to by testing in Firefox 22 where that issue is known to be present
