### PR TITLE
Use Date.now() for timestamp

### DIFF
--- a/src/Native/AnimationFrame.js
+++ b/src/Native/AnimationFrame.js
@@ -1,23 +1,9 @@
 var _elm_lang$animation_frame$Native_AnimationFrame = function()
 {
-
-var hasStartTime =
-	window.performance &&
-	window.performance.timing &&
-	window.performance.timing.navigationStart;
-
-var navStart = hasStartTime
-	? window.performance.timing.navigationStart
-	: Date.now();
-
 var rAF = _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 {
-	var id = requestAnimationFrame(function(time) {
-		var timeNow = time
-			? (time > navStart ? time : time + navStart)
-			: Date.now();
-
-		callback(_elm_lang$core$Native_Scheduler.succeed(timeNow));
+	var id = requestAnimationFrame(function() {
+		callback(_elm_lang$core$Native_Scheduler.succeed(Date.now()));
 	});
 
 	return function() {


### PR DESCRIPTION
As discussed in https://groups.google.com/forum/#!topic/elm-dev/RU2ZZqDFOwU

For the reference of those who are new to the discussion, `performance.now()` and the timestamp  passed to `requestAnimationFrame` are [High Resolution Timestamps](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp). There are two things to note about these types of timing information:
- They are read from a separate clock than `Date.now()`
- Even though they are in theory supposed to be relative to `performance.timing.navigationStart`, this is not reliable over long periods of time and these timestamps [are only for measuring relative to each other](https://twitter.com/jlongster/status/768122598408544256).

Below is a screenshot I took of how drastically different the two methods of reading the current time can become in Firefox:

![screen shot 2016-08-23 at 12 21 07 pm](https://cloud.githubusercontent.com/assets/1508245/17951145/8a01ba2e-6a25-11e6-8c7f-f394118aa10b.png)

To avoid situations where we are comparing two things that aren't supposed to be compared and cause problems like #6 we can just use `Date.now()` and still get very smooth animations even though we don't have that 5μs accuracy.

Alternatives to this approach are:
- Add a new task to `Native.AnimationFrame` for getting `performance.now()` and use that as the initial stamp for `diffs`, and then succeed with _both_ `Date.now()` and the high res stamp within `rAF`. This would allow `diffs` to continue to be high-res and `times` wouldn't end up being inaccurate.
  - Pros: `diffs` is still high-res
  - `(::)`: code becomes a bit more complicated
- Remove `times` altogether
  - Pros: the inaccurate thing is no longer inaccurate because it doesn't exist
  - `(::)`: the API changes, and people who were using `times` have to figure something else out
